### PR TITLE
Add ability to reconfigure number of LEDs in strip at runtime

### DIFF
--- a/PICxel.cpp
+++ b/PICxel.cpp
@@ -77,6 +77,20 @@ bool PICxel::setNumberOfLEDs(
   uint8_t* pixelBrightnessArrayPtr
 )
 {
+  // Always attempt to deallocate old pointers
+  if (colorArray != NULL)
+  {
+    free(colorArray);
+  }
+  if (originalColorArray != NULL)
+  {
+    free(originalColorArray);
+  }
+  if (pixelBrightnessArray != NULL)
+  {
+    free(pixelBrightnessArray);
+  }
+
   if (memoryMode == alloc)
   {
     // User is asking us to allocate the pixel color arrays using calloc
@@ -189,17 +203,40 @@ bool PICxel::setNumberOfLEDs(
 /* Change the static array, freeing an old calloc array if existing     */
 /* and change memory mode for future operations if applicable           */
 /************************************************************************/
-void PICxel::setArrayPointer(uint8_t* colorPtr)
+void PICxel::setArrayPointer(
+  uint8_t* colorArrayPtr,
+  uint8_t* originalColorArrayPtr,
+  uint8_t* pixelBrightnessArrayPtr
+)
 {
-  if (memoryMode == alloc) 
+  if (memoryMode == alloc)
   {
-    if (colorArray != NULL) 
+    if (colorArray != NULL)
     {
       free(colorArray);
     }
+    if (originalColorArray != NULL)
+    {
+      free(originalColorArray);
+    }
+    if (pixelBrightnessArray != NULL)
+    {
+      free(pixelBrightnessArray);
+    }
     memoryMode = noalloc;
   }
-  colorArray = colorPtr;
+  if (colorArrayPtr != NULL)
+  {
+    colorArray = colorArrayPtr;
+  }
+  if (originalColorArrayPtr != NULL)
+  {
+    originalColorArrayPtr = originalColorArrayPtr;
+  }
+  if (pixelBrightnessArrayPtr != NULL)
+  {
+    pixelBrightnessArray = colorArrayPtr;
+  }
 }
 
 

--- a/PICxel.cpp
+++ b/PICxel.cpp
@@ -63,21 +63,26 @@ PICxel::PICxel(
   portClr(portOutputRegister(digitalPinToPort(pixelPin)) + 1),
   pinMask(digitalPinToBitMask(pixelPin))
 {
-  setNumberOfLEDs(pixelCount);
+  setNumberOfLEDs(pixelCount, colorArrayPtr, originalColorArrayPtr, pixelBrightnessArrayPtr);
 }
 
 /************************************************************************/
 /* Change the number of pixels and reallocate the new memory size       */
 /* Return true if everything went OK, false if not.                     */
 /************************************************************************/
-bool PICxel::setNumberOfLEDs(uint16_t num) 
+bool PICxel::setNumberOfLEDs(
+  uint16_t pixelCount,
+  uint8_t* colorArrayPtr,
+  uint8_t* originalColorArrayPtr,
+  uint8_t* pixelBrightnessArrayPtr
+)
 {
   if (memoryMode == alloc)
   {
     // User is asking us to allocate the pixel color arrays using calloc
     if (colorMode == GRB)
     {
-      colorArraySizeBytes =  3 * pixelCount;
+      colorArraySizeBytes = 3 * pixelCount;
       colorArray = (uint8_t *)calloc(colorArraySizeBytes, sizeof(uint8_t));
 
       // Only allocate extra two arrays if user wants per-pixel brightness

--- a/PICxel.cpp
+++ b/PICxel.cpp
@@ -5,8 +5,9 @@
 /*  the PIC32 line of microcontrollers.                                 */
 /*                                                                      */
 /*  tested supported boards:                                            */
-/*    - Digilent UNO32                                                  */
-/*    - Digilent UC32                                                   */
+/*    - Digilent UNO32 (80MHz)                                          */
+/*    - Digilent UC32 (80MHz)                                           */
+/*    - chipKIT Lenny (40MHz)                                           */
 /*                                                                      */
 /*  This library is protected under the GNU GPL v3.0 license            */
 /*  http://www.gnu.org/licenses/                                        */
@@ -15,13 +16,17 @@
 /*                          well as simplifying the main                */
 /*                          GRBrefreshLEDs() function.                  */
 /*                          Tested on 40, 48, 80 and 200 MHz boards     */
-/* 07/28/2017 Brian Schmalz Reformatted to ease readability             */
+/* 07/28/2018 Brian Schmalz Reformatted to ease readability             */
 /*                          Added more comments, function header blocks */
 /*                          Added support for per-pixel brightness      */
 /*                            values by adding per-pixel brightness     */
 /*                            array, new functions to support setting   */
 /*                            it, and new array for storing original    */
 /*                            color values                              */
+/* 10/14/2018 Matt Jenkins Added support for changing number of LEDs   */
+/*                          on the fly and reallocating and freeing     */
+/*                          memory when needed.                         */
+/*                          Tested on 40MHz Lenny                       */
 /*                                                                      */
 /* TODO: Update HSV delays for F_CPU other than 80MHz                   */
 /************************************************************************/
@@ -57,6 +62,15 @@ PICxel::PICxel(
   portSet(portOutputRegister(digitalPinToPort(pixelPin)) + 2),
   portClr(portOutputRegister(digitalPinToPort(pixelPin)) + 1),
   pinMask(digitalPinToBitMask(pixelPin))
+{
+  setNumberOfLEDs(pixelCount);
+}
+
+/************************************************************************/
+/* Change the number of pixels and reallocate the new memory size       */
+/* Return true if everything went OK, false if not.                     */
+/************************************************************************/
+bool PICxel::setNumberOfLEDs(uint16_t num) 
 {
   if (memoryMode == alloc)
   {
@@ -148,6 +162,7 @@ PICxel::PICxel(
         free(pixelBrightnessArray);
       }
     }
+    return false;
   }
   else
   {
@@ -162,7 +177,26 @@ PICxel::PICxel(
       memset((void *)pixelBrightnessArray, 0xFF, pixelCount);
     }
   }
+  return true;
 }
+
+/************************************************************************/
+/* Change the static array, freeing an old calloc array if existing     */
+/* and change memory mode for future operations if applicable           */
+/************************************************************************/
+void PICxel::setArrayPointer(uint8_t* colorPtr)
+{
+  if (memoryMode == alloc) 
+  {
+    if (colorArray != NULL) 
+    {
+      free(colorArray);
+    }
+    memoryMode = noalloc;
+  }
+  colorArray = colorPtr;
+}
+
 
 /************************************************************************/
 /*  Destructor for the PICxel class                                     */

--- a/PICxel.h
+++ b/PICxel.h
@@ -115,7 +115,11 @@ public:
     uint8_t* originalColorArrayPtr = NULL,
     uint8_t* pixelBrightnessArrayPtr = NULL
   );
-  void setArrayPointer(uint8_t* colorPtr);
+  void setArrayPointer(
+    uint8_t* colorArrayPtr,
+    uint8_t* originalColorArrayPtr = NULL,
+    uint8_t* pixelBrightnessArrayPtr = NULL
+  );
   uint8_t* getColorArray(void);
   /* Returns the global brightness value */
   uint8_t getBrightness(void);

--- a/PICxel.h
+++ b/PICxel.h
@@ -109,7 +109,13 @@ public:
 
 //get class variable functions
   uint16_t getNumberOfLEDs(void);
-  bool setNumberOfLEDs(uint16_t);
+  bool setNumberOfLEDs(
+    uint16_t pixelCount,
+    uint8_t* colorArrayPtr = NULL,
+    uint8_t* originalColorArrayPtr = NULL,
+    uint8_t* pixelBrightnessArrayPtr = NULL
+  );
+  void setArrayPointer(uint8_t* colorPtr);
   uint8_t* getColorArray(void);
   /* Returns the global brightness value */
   uint8_t getBrightness(void);

--- a/PICxel.h
+++ b/PICxel.h
@@ -109,6 +109,7 @@ public:
 
 //get class variable functions
   uint16_t getNumberOfLEDs(void);
+  bool setNumberOfLEDs(uint16_t);
   uint8_t* getColorArray(void);
   /* Returns the global brightness value */
   uint8_t getBrightness(void);

--- a/examples/PICxel_SetNumberOfLEDs/PICxel_SetNumberOfLEDs.ino
+++ b/examples/PICxel_SetNumberOfLEDs/PICxel_SetNumberOfLEDs.ino
@@ -1,0 +1,64 @@
+/************************************************************************
+ *  PICxel_SetNumberOfLEDso - PIC32 Neopixel Library Demo
+ *
+ *  This sketch shows how to use the setNumberOfLEDs() function
+ *
+ *  supported boards:
+ *    - all chipKIT boards
+ *
+ *  This library is protected under the GNU GPL v3.0 license
+ *  http://www.gnu.org/licenses/
+ *
+ *  Even thought this sketch shows setNumberOfLEDs() with just one
+ *  parameter, it is possible to pass in four, See PICxel.cpp
+ *  and PICxel.h for paramter info. When you only use on paraemter,
+ *  the other paramters defult to NULL. But if you send them in,
+ *  you can control the arrays (if you initalized the PICxel object
+ *  with a memory mode of noalloc)
+ ************************************************************************/
+
+#include <PICxel.h>
+
+#define MAXIMUM_NUMBER_OF_LEDS      15
+#define LED_PIN                      0
+#define MILLISECOND_DELAY           50
+
+// PICxel constructor(uint8_t # of LEDs, uint8_t pin #);
+PICxel strip(MAXIMUM_NUMBER_OF_LEDS, LED_PIN);
+
+uint8_t CurrentNumberOfLEDs = MAXIMUM_NUMBER_OF_LEDS;
+
+void setup()
+{
+  strip.begin();
+  strip.setBrightness(30);
+  strip.clear();
+}
+
+void loop()
+{
+  for (int i = 0; i < strip.getNumberOfLEDs(); i++)
+  {
+    strip.GRBsetLEDColor(i, 255, 0, 0);
+    strip.refreshLEDs();
+    delay(MILLISECOND_DELAY);
+  }
+
+  for (int i = strip.getNumberOfLEDs(); i >= 0; i--)
+  {
+    strip.GRBsetLEDColor(i, 0, 255, 0);
+    strip.refreshLEDs();
+    delay(MILLISECOND_DELAY);
+  }
+  CurrentNumberOfLEDs--;
+  if (CurrentNumberOfLEDs == 0)
+  {
+    CurrentNumberOfLEDs = MAXIMUM_NUMBER_OF_LEDS;
+  }
+  /* Reconfigure the PICxel object to have a different number of LEDs.
+   *  Note that you can't ask for more memory here than you have heap space for, 
+   *  and eventually the heap may get fragmented, so be careful how many times
+   *  you reset the number of LEDs.
+   */
+  strip.setNumberOfLEDs(CurrentNumberOfLEDs);
+}


### PR DESCRIPTION
This is a slight reimplementation of this pull request : 
https://github.com/mwingerson/PICxel/pull/3

New functions were added for sketches to change the number of LEDs in a strip while the sketch is running. See the new example file for some info on how to use the new setNumberOfLEDs() functions. 

Some reworking of the constructor was also done to remove redundant code.

